### PR TITLE
Get FriendsDontPay amounts

### DIFF
--- a/Dumplings.Cli/Command.cs
+++ b/Dumplings.Cli/Command.cs
@@ -28,6 +28,6 @@ namespace Dumplings.Cli
         CountCoinJoins,
         Upload,                      // Upload data to Database.
         DailyVolumes,
-        FreeMixed
+        FriendsDontPay
     }
 }

--- a/Dumplings.Cli/Command.cs
+++ b/Dumplings.Cli/Command.cs
@@ -27,6 +27,7 @@ namespace Dumplings.Cli
         WabiSabiCoordStats,         // Calculate the monthly volumes of different kind of WabiSabi coinjoins of equal values.
         CountCoinJoins,
         Upload,                      // Upload data to Database.
-        DailyVolumes
+        DailyVolumes,
+        FreeMixed
     }
 }

--- a/Dumplings.Cli/Program.cs
+++ b/Dumplings.Cli/Program.cs
@@ -143,9 +143,9 @@ namespace Dumplings.Cli
                     {
                         stat.CalculateWabiSabiCoordStats(GetXpub(args));
                     }
-                    else if (command == Command.FreeMixed)
+                    else if (command == Command.FriendsDontPay)
                     {
-                        stat.CalculateDailyFreeMixedAmount();
+                        stat.CalculateDailyFriendsDontPayAmount();
                     }
                     else if (command == Command.Upload)
                     {

--- a/Dumplings.Cli/Program.cs
+++ b/Dumplings.Cli/Program.cs
@@ -143,6 +143,10 @@ namespace Dumplings.Cli
                     {
                         stat.CalculateWabiSabiCoordStats(GetXpub(args));
                     }
+                    else if (command == Command.FreeMixed)
+                    {
+                        stat.CalculateDailyFreeMixedAmount();
+                    }
                     else if (command == Command.Upload)
                     {
                         stat.UploadToDatabase();

--- a/Dumplings/Displaying/Display.cs
+++ b/Dumplings/Displaying/Display.cs
@@ -145,6 +145,32 @@ namespace Dumplings.Displaying
             }
         }
 
+        public static void DisplayWasabiResults(Dictionary<YearMonthDay, decimal> wasabiResults, out List<string> resultList)
+        {
+            resultList = new();
+
+            resultList.Add($"Date;Wasabi");
+
+            foreach (var yearMonthDay in wasabiResults
+                .Keys
+                .Distinct()
+                .OrderBy(x => x.Year)
+                .ThenBy(x => x.Month)
+                .ThenBy(x => x.Day))
+            {
+                if (!wasabiResults.TryGetValue(yearMonthDay, out decimal wasabi))
+                {
+                    wasabi = 0;
+                }
+
+                resultList.Add($"{yearMonthDay};{wasabi:0.00}");
+            }
+            foreach (var line in resultList)
+            {
+                Console.WriteLine(line);
+            }
+        }
+
         public static void DisplayWasabiSamuriResults(Dictionary<YearMonth, Money> wasabiResults, Dictionary<YearMonth, Money> samuriResults, out List<string> resultList)
         {
             resultList = new();

--- a/Dumplings/Stats/Statista.cs
+++ b/Dumplings/Stats/Statista.cs
@@ -1379,7 +1379,7 @@ namespace Dumplings.Stats
 
         public Dictionary<YearMonthDay, decimal> CalculateDailyFriendsDontPayAmount()
         {
-            var postMixTxHashes = ScannerFiles.Wasabi2PostMixTxHashes;
+            var postMixTxHashes = ScannerFiles.Wasabi2PostMixTxHashes.ToDictionary(x => x, y => byte.MinValue);
             var ww2CoinJoins = ScannerFiles.Wasabi2CoinJoins;
             var myDic = new Dictionary<YearMonthDay, decimal>();
 
@@ -1392,7 +1392,7 @@ namespace Dumplings.Stats
                     var yearMonthDay = new YearMonthDay(blockTimeValue.Year, blockTimeValue.Month, blockTimeValue.Day);
 
                     decimal sum = 0;
-                    foreach (var input in tx.Inputs.Where(x => postMixTxHashes.Contains(x.OutPoint.Hash)))
+                    foreach (var input in tx.Inputs.Where(x => postMixTxHashes.ContainsKey(x.OutPoint.Hash)))
                     {
                         sum += input.PrevOutput.Value.ToDecimal(MoneyUnit.BTC);
                     }

--- a/Dumplings/Stats/Statista.cs
+++ b/Dumplings/Stats/Statista.cs
@@ -1377,6 +1377,46 @@ namespace Dumplings.Stats
             return myDic;
         }
 
+        public Dictionary<YearMonthDay, decimal> CalculateDailyFreeMixedAmount()
+        {
+            var postMixTxHashes = ScannerFiles.Wasabi2PostMixTxHashes;
+            var ww2CoinJoins = ScannerFiles.Wasabi2CoinJoins;
+            var myDic = new Dictionary<YearMonthDay, decimal>();
+
+            foreach (var tx in ww2CoinJoins)
+            {
+                var blockTime = tx.BlockInfo.BlockTime;
+                if (blockTime.HasValue)
+                {
+                    var blockTimeValue = blockTime.Value;
+                    var yearMonthDay = new YearMonthDay(blockTimeValue.Year, blockTimeValue.Month, blockTimeValue.Day);
+
+                    decimal sum = 0;
+                    foreach (var input in tx.Inputs.Where(x => postMixTxHashes.Contains(x.OutPoint.Hash)))
+                    {
+                        sum += input.PrevOutput.Value.ToDecimal(MoneyUnit.BTC);
+                    }
+
+                    if (myDic.TryGetValue(yearMonthDay, out decimal current))
+                    {
+                        myDic[yearMonthDay] = current + sum;
+                    }
+                    else
+                    {
+                        myDic.Add(yearMonthDay, sum);
+                    }
+                }
+            }
+
+            Display.DisplayWasabiResults(myDic, out var resultList);
+            if (!string.IsNullOrWhiteSpace(FilePath))
+            {
+                File.WriteAllLines(FilePath, resultList);
+            }
+
+            return myDic;
+        }
+
         public void CalculateWasabiCoordStats(ExtPubKey[] xpubs)
         {
             using (BenchmarkLogger.Measure())

--- a/Dumplings/Stats/Statista.cs
+++ b/Dumplings/Stats/Statista.cs
@@ -1377,7 +1377,7 @@ namespace Dumplings.Stats
             return myDic;
         }
 
-        public Dictionary<YearMonthDay, decimal> CalculateDailyFreeMixedAmount()
+        public Dictionary<YearMonthDay, decimal> CalculateDailyFriendsDontPayAmount()
         {
             var postMixTxHashes = ScannerFiles.Wasabi2PostMixTxHashes;
             var ww2CoinJoins = ScannerFiles.Wasabi2CoinJoins;

--- a/Dumplings/Stats/Statista.cs
+++ b/Dumplings/Stats/Statista.cs
@@ -1377,7 +1377,7 @@ namespace Dumplings.Stats
             return myDic;
         }
 
-        public Dictionary<YearMonthDay, decimal> CalculateDailyFriendsDontPayAmount()
+        public void CalculateDailyFriendsDontPayAmount()
         {
             var postMixTxHashes = ScannerFiles.Wasabi2PostMixTxHashes.ToDictionary(x => x, y => byte.MinValue);
             var ww2CoinJoins = ScannerFiles.Wasabi2CoinJoins;
@@ -1413,8 +1413,6 @@ namespace Dumplings.Stats
             {
                 File.WriteAllLines(FilePath, resultList);
             }
-
-            return myDic;
         }
 
         public void CalculateWasabiCoordStats(ExtPubKey[] xpubs)


### PR DESCRIPTION
This PR adds a new command, `FreeMixed`, which gives back daily amounts of how many bitcoins were mixed freely, AKA the sum of the amounts of WW2 coinjoin inputs, which are coming from `PostMixTx`s.

Edit:
This PR aims implement Friends Don't Pay calculation, other will follow in new PRs.